### PR TITLE
promql: group_left and group_right do not require labels, making them…

### DIFF
--- a/promql/PromQLParser.g4
+++ b/promql/PromQLParser.g4
@@ -114,8 +114,8 @@ without: WITHOUT labelNameList;
 grouping:   (on_ | ignoring) (groupLeft | groupRight)?;
 on_:         ON labelNameList;
 ignoring:   IGNORING labelNameList;
-groupLeft:  GROUP_LEFT labelNameList;
-groupRight: GROUP_RIGHT labelNameList;
+groupLeft:  GROUP_LEFT labelNameList?;
+groupRight: GROUP_RIGHT labelNameList?;
 
 // Label names
 


### PR DESCRIPTION
… optional

See https://prometheus.io/docs/prometheus/latest/querying/operators/#group-modifiers.